### PR TITLE
switch to github pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+dev.myhdl.org

--- a/travis-deploy-ghpages.sh
+++ b/travis-deploy-ghpages.sh
@@ -7,7 +7,7 @@ repo_url="https://myhdl-bot:$GH_TOKEN@github.com/myhdl/site-myhdl-dev.git"
 pages_dir=~/myhdl/ghpages
 
 git clone -b gh-pages $repo_url $pages_dir
-rsync -az --delete --exclude .git --exclude CNAME _build/ $pages_dir/
+rsync -az --delete --exclude .git _build/ $pages_dir/
 
 cd $pages_dir
 if [[ -z $(git status -s) ]]; then


### PR DESCRIPTION
The travis script has been working fine for a while now, and is being served on http://myhdldev.jck.io

Adding the following record to the DNS:
`dev 3600 IN CNAME myhdl.github.io.`

And merging this PR will remove the need to push built pages to master. Additionally, travis will notify a user if urubu failed on a build.
