### PR TITLE
fixed typos

### DIFF
--- a/meps/mep-113.md
+++ b/meps/mep-113.md
@@ -14,7 +14,7 @@ The signal names that are used in the VHDL and Verilog are important in both FPG
 
 To prevent excessive signal name collisions, delimiters are used to separate variables in different "namespaces". Currently underscores are used as a delimiter to denote a signal's location in the module hierarchy (functions that return generators) as well as it's membership in an interface (classes with members that are signals). Underscores are also quite common in properly styled python variables.
 
-The triple usage of underscores increases the likelihood of signal name collisions and makes the VHDL and Verilog more ambiguous. A signal with the name a_b in the VHDL or Verilog could mean that there was an interface named a whose member is b, or it could mean that there was a module named a with a local signal named c, or it could just be a signal in the top level whose name is a_c.
+The triple usage of underscores increases the likelihood of signal name collisions and makes the VHDL and Verilog more ambiguous. A signal with the name a_b in the VHDL or Verilog could mean that there was an interface named a whose member is b, or it could mean that there was a module named a with a local signal named b, or it could just be a signal in the top level whose name is a_b.
 
 One of the main reasons why we are using underscores in the first place is because there aren't really any other valid characters that you can use in identifiers in VHDL and Verilog unless you use escaped/extended identifiers. Escaped/extended identifiers are a standard way to use additional characters in signal names. Usually they are used by HDL tools to export netlists because the internal netlist structure supports different character sets than VHDL or Verilog.
 
@@ -22,7 +22,7 @@ If we were to change the hierarchy and interface delimiter, we would reduce our 
 
 # Specification #
 
-All signals that are an interface or not in the top level function must have their names escaped. In Verilog that is accomplished by starting the name with a backslash '\' and terminated the name with whitespace. In VHDL this is accomplished by enclosing the name between backslashes '\'. Extended identifiers in VHDL are case sensitive.
+All signals that are in an interface or not in the top level function must have their names escaped. In Verilog that is accomplished by starting the name with a backslash '\' and terminated the name with whitespace. In VHDL this is accomplished by enclosing the name between backslashes '\'. Extended identifiers in VHDL are case sensitive.
 
 Whether top level, non-interface signals are also escaped is beyond the scope of this proposal, although doing so would provide greater consistency as well as resolve collisions with VHDL and Verilog keywords and VHDL case insensitivity.
 
@@ -44,7 +44,7 @@ signal \top/middle/bottom_signal : std_logic;
 
 ## Interface membership ##
 
-In many programming languages, (including python), the "." operator is used to access attributes of an object. By using the "." in signal names, this would mirror the myHDL code that accessed the interface member to begin with.
+In many programming languages (including python) the "." operator is used to access attributes of an object. By using the "." in signal names, this would mirror the myHDL code that accessed the interface member to begin with.
 
 Verilog Example
 ``` Verilog


### PR DESCRIPTION
I fixed the inconsistent signal name a_b, added 'in' because signals are not interfaces, and removed redundant commas.